### PR TITLE
Fix repository urls in package.json files

### DIFF
--- a/extras/com.unity.rpc/Tests/package.json
+++ b/extras/com.unity.rpc/Tests/package.json
@@ -6,7 +6,7 @@
     "version": "0.0.0-placeholder",
     "repository" : {
       "type" : "git",
-      "url": "git@github.com:Unity-Technologies/com/unity.rpc.git",
+      "url": "https://github.com/Unity-Technologies/com.unity.rpc.git",
       "directory": "",
       "revision": ""
     },

--- a/src/com.unity.rpc/package.json
+++ b/src/com.unity.rpc/package.json
@@ -6,7 +6,7 @@
   "unity": "2018.4",
   "repository": {
     "type": "git",
-    "url": "git@github.cds.internal.unity3d.com:unity/Unity.Ipc.git",
+    "url": "https://github.com/Unity-Technologies/com.unity.rpc.git",
     "revision": "hash"
   },
   "testPackages": {


### PR DESCRIPTION
The package.json file on the main package was pointing to the old repo, and the test package had a typo, ugh.